### PR TITLE
Issue 27 bottom navigator component

### DIFF
--- a/client/public/img/bottomNavIcon1.svg
+++ b/client/public/img/bottomNavIcon1.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 6H21" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 12H21" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 18H21" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 6H3.01" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 12H3.01" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 18H3.01" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/img/bottomNavIcon2.svg
+++ b/client/public/img/bottomNavIcon2.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 3H3V10H10V3Z" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 3H14V10H21V3Z" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 14H14V21H21V14Z" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 14H3V21H10V14Z" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/img/bottomNavIcon3.svg
+++ b/client/public/img/bottomNavIcon3.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 21V19C20 17.9391 19.5786 16.9217 18.8284 16.1716C18.0783 15.4214 17.0609 15 16 15H8C6.93913 15 5.92172 15.4214 5.17157 16.1716C4.42143 16.9217 4 17.9391 4 19V21" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 11C14.2091 11 16 9.20914 16 7C16 4.79086 14.2091 3 12 3C9.79086 3 8 4.79086 8 7C8 9.20914 9.79086 11 12 11Z" stroke="#0B1920" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/ui/bottomNav.tsx
+++ b/client/src/components/ui/bottomNav.tsx
@@ -1,10 +1,5 @@
 import Image from "next/image";
 
-import icon1 from "/img/bottomNavIcon1.svg";
-
-import icon2 from "../../../public/img/bottomNavIcon2.svg";
-import icon3 from "../../../public/img/bottomNavIcon3.svg";
-
 const iconLists = [
   {
     ref: "/img/bottomNavIcon1.svg",

--- a/client/src/components/ui/bottomNav.tsx
+++ b/client/src/components/ui/bottomNav.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+
+import icon1 from "/img/bottomNavIcon1.svg";
+
+import icon2 from "../../../public/img/bottomNavIcon2.svg";
+import icon3 from "../../../public/img/bottomNavIcon3.svg";
+
+const iconLists = [
+  {
+    ref: "/img/bottomNavIcon1.svg",
+    alt: "Icon of my tasks",
+    text: "My Tasks",
+  },
+  {
+    ref: "/img/bottomNavIcon2.svg",
+    alt: "Icon of market",
+    text: "Market",
+  },
+  {
+    ref: "/img/bottomNavIcon3.svg",
+    alt: "Icon of me",
+    text: "Me",
+  },
+];
+
+export default function BottomNav() {
+  const iconItems = iconLists.map((iconItem) => (
+    <div className="flex w-1/3 flex-col items-center">
+      <div>
+        <Image src={iconItem.ref} alt={iconItem.alt} width={24} height={24} />
+      </div>
+      <p>{iconItem.text}</p>
+    </div>
+  ));
+  return <div className="flex h-20 pt-2 text-xs leading-3">{iconItems}</div>;
+}

--- a/client/src/components/ui/bottomNav.tsx
+++ b/client/src/components/ui/bottomNav.tsx
@@ -19,13 +19,21 @@ const iconLists = [
 ];
 
 export default function BottomNav() {
-  const iconItems = iconLists.map((iconItem) => (
-    <div className="flex w-1/3 flex-col items-center">
-      <div>
-        <Image src={iconItem.ref} alt={iconItem.alt} width={24} height={24} />
-      </div>
-      <p>{iconItem.text}</p>
+  return (
+    <div className="flex h-20 pt-2 text-xs leading-3">
+      {iconLists.map((iconItem, index) => (
+        <div key={index} className="flex w-1/3 flex-col items-center">
+          <div>
+            <Image
+              src={iconItem.ref}
+              alt={iconItem.alt}
+              width={24}
+              height={24}
+            />
+          </div>
+          <p>{iconItem.text}</p>
+        </div>
+      ))}
     </div>
-  ));
-  return <div className="flex h-20 pt-2 text-xs leading-3">{iconItems}</div>;
+  );
 }


### PR DESCRIPTION
## Change Summary
Add 3 bottom navigation icons svg files. Add bottomNav component using tailwind font size of 12px, component height of 80px, width of the viewport

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
Font size, component height are a little different from the Figma design. Font is not defined


# Related issue

- Resolve #27