### PR TITLE
Issue 110 - Warn about required fields not being filled in in forms

### DIFF
--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -181,18 +181,26 @@ export function Form({ children, onSubmit, className }: FormProps) {
             <InputContext.Provider
               value={{
                 value: values[i].value,
-                onChange: (e: React.ChangeEvent<HTMLTextTargetElement>) => {
+                onChange: (e) => {
                   setValues[i](e.target.value);
-                  if (errors[values[i].name || ""]) {
+
+                  if (child.props.required) {
                     setErrors((prev) => {
-                      const { [values[i].name || ""]: _, ...rest } = prev;
-                      return rest;
+                      const updatedErrors = {
+                        ...prev,
+                        [values[i].name || ""]: !e.target.value,
+                      };
+                      return updatedErrors;
                     });
                   }
                 },
               }}
             >
-              {child}
+              <div
+                className={`${errors[child.props.name] ? "rounded-lg outline outline-2 outline-red-500" : ""}`}
+              >
+                {child}
+              </div>
             </InputContext.Provider>
             {errors[values[i].name || ""] && (
               <ErrorCallout text="This is a required field!" />

--- a/client/src/components/ui/inputs.tsx
+++ b/client/src/components/ui/inputs.tsx
@@ -136,7 +136,6 @@ export function SingleLineInput({
   label,
   placeholder = "",
   type,
-  required,
 }: SingleLineInputProps) {
   const [isSelected, setIsSelected] = useState(false);
   const id = useId();
@@ -171,7 +170,7 @@ export function SingleLineInput({
   return (
     <TextInputContainer
       value={value}
-      label={label + (required ? " (required)" : "")}
+      label={label}
       placeholder={placeholder}
       id={id}
       isSelected={isSelected}

--- a/client/src/components/ui/inputs.tsx
+++ b/client/src/components/ui/inputs.tsx
@@ -136,6 +136,7 @@ export function SingleLineInput({
   label,
   placeholder = "",
   type,
+  required,
 }: SingleLineInputProps) {
   const [isSelected, setIsSelected] = useState(false);
   const id = useId();
@@ -162,13 +163,15 @@ export function SingleLineInput({
           },
         });
       }
+    } else {
+      onChange?.(e);
     }
   }
 
   return (
     <TextInputContainer
       value={value}
-      label={label}
+      label={label + (required ? " (required)" : "")}
       placeholder={placeholder}
       id={id}
       isSelected={isSelected}
@@ -185,7 +188,7 @@ export function SingleLineInput({
         type={type === "price" ? "number" : type}
         value={value}
         placeholder={placeholder}
-        onChange={onChange}
+        onChange={handleOnChange}
         onBlur={handleOnChange}
         className={valueStyle}
       />


### PR DESCRIPTION
## Change Summary
Extends the `<Form/>` component so that required fields display an error if they are left empty.

![Screenshot from 2024-07-19 12-51-34](https://github.com/user-attachments/assets/fd30894e-67a7-40a6-aaf8-4cf2d7965284)

### Change Form

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information

The original ticket suggested including "(required)" in the label automatically, but I have excluded from this PR.

It consumes a lot of space and feels unnecessary, especially if most fields will be required anyway. Might be better to do the inverse and label non-required fields as "(optional)".

![Screenshot from 2024-07-19 12-41-38](https://github.com/user-attachments/assets/1310b8f8-119b-4e63-bff6-32acf836cd25)


# Related issue

- Resolve #110