### PR TITLE
Fix POST request handling to create bids for a specific task

### DIFF
--- a/server/app/views.py
+++ b/server/app/views.py
@@ -53,9 +53,9 @@ class BidsViewSet(viewsets.ModelViewSet):
             task = Tasks.objects.get(task_id=task_id)
         except Tasks.DoesNotExist:
             return Response({'status': 'error', 'message': 'Task not found.'}, status=status.HTTP_404_NOT_FOUND)
-        data = request.data
+        data = request.data.copy()
         data['task_id'] = task_id
-        data['bidder_id'] = request.user.id
+        data['bidder_id'] = request.data['bidder_id']
         # check task status
         if task.status != 'open':
             return Response({'status': 'error', 'message': 'Cannot place bid on a closed task.'}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### Background
The POST request for the URL `/api/app/tasks/<task_id>/bids/` was previously not working, preventing users from creating new bids for a specific task.

### Fix
- Updated the API endpoint to handle POST requests correctly.
- Modified the request handling logic to allow the creation of new bids for the specified task.

### Testing
- Tested the POST request to ensure new bids can be created successfully.
- Verified that existing functionality is not affected by the changes.

### Additional Notes
- If there are any related issues or tickets, mention them here.
- Any additional context or information that reviewers might need.